### PR TITLE
utf8 support

### DIFF
--- a/public_html/text2hash.js
+++ b/public_html/text2hash.js
@@ -32,7 +32,7 @@ $(document).ready(function(){
 				break;
 		}
 
-		md.update(text);
+		md.update(text, 'utf8');
 		$("#hashed").val(md.digest().toHex());
 	};
 


### PR DESCRIPTION
To support accents and everything (we use the tool on frwiki). People who have used accents before, for example, have a bad hash.